### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/dapdommaAZ400/24787b20-8176-4c07-8870-9343f869aefc/78cfd702-457c-4b72-b314-8afaea66271c/_apis/work/boardbadge/fb1c61fd-4def-4cda-88e9-abfe8f6dea52)](https://dev.azure.com/dapdommaAZ400/24787b20-8176-4c07-8870-9343f869aefc/_boards/board/t/78cfd702-457c-4b72-b314-8afaea66271c/Microsoft.RequirementCategory)
 # Tailwind Traders Website
 
 ![Tailwind Traders Website](Documents/Images/Website.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#203](https://dev.azure.com/dapdommaAZ400/24787b20-8176-4c07-8870-9343f869aefc/_workitems/edit/203). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.